### PR TITLE
Add common extractions for Task and Job ID from pod labels

### DIFF
--- a/pod/labels.go
+++ b/pod/labels.go
@@ -32,6 +32,25 @@ const (
 	LabelKeyCapacityGroup = "titus.netflix.com/capacity-group"
 )
 
+func extractStringLabel(pod *corev1.Pod, label string) (string, error) {
+	value, ok := pod.GetLabels()[label]
+	if !ok {
+		return "", fmt.Errorf("pod doesn't contain label %s", label)
+	}
+
+	return value, nil
+}
+
+// JobID returns the Titus Job ID value from the labels of a pod
+func JobID(pod *corev1.Pod) (string, error) {
+	return extractStringLabel(pod, LabelKeyJobId)
+}
+
+// TaskID returns the Titus Task ID value from the labels of a pod
+func TaskID(pod *corev1.Pod) (string, error) {
+	return extractStringLabel(pod, LabelKeyTaskId)
+}
+
 // Is the control plane indicating that it's sending the resources in bytes?
 func ByteUnitsEnabled(pod *corev1.Pod) (bool, error) {
 	bytesEnabled, ok := pod.GetLabels()[LabelKeyByteUnitsEnabled]

--- a/pod/labels_test.go
+++ b/pod/labels_test.go
@@ -1,0 +1,61 @@
+package pod
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPodTaskID(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+			Labels: map[string]string{
+				LabelKeyTaskId: "00000000-0000-0000-0000-000000000000",
+			},
+		},
+	}
+
+	id, err := TaskID(pod)
+	assert.NilError(t, err)
+	assert.Equal(t, id, "00000000-0000-0000-0000-000000000000")
+
+	unlabeledPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+	}
+
+	id, err = TaskID(unlabeledPod)
+	assert.Error(t, err, "pod doesn't contain label "+LabelKeyTaskId)
+}
+
+func TestPodJobID(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+			Labels: map[string]string{
+				LabelKeyJobId: "00000000-0000-0000-0000-000000000000",
+			},
+		},
+	}
+
+	id, err := JobID(pod)
+	assert.NilError(t, err)
+	assert.Equal(t, id, "00000000-0000-0000-0000-000000000000")
+
+	unlabeledPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+	}
+
+	id, err = JobID(unlabeledPod)
+	assert.Error(t, err, "pod doesn't contain label "+LabelKeyJobId)
+}


### PR DESCRIPTION
Add two common accessors for extracting the TaskID and JobID from the labels.