### PR TITLE
Add an annotation indicating what index user-specified env vars start at

### DIFF
--- a/docs/examples/complete-pod.yaml
+++ b/docs/examples/complete-pod.yaml
@@ -13,13 +13,17 @@ metadata:
     workload.netflix.com/detail: testdetail
     workload.netflix.com/sequence: v001
     workload.netflix.com/owner-email: myuser@netflix.com
+
     # Titus-specific fields
+
     v3.job.titus.netflix.com/accepted-timestamp-ms: "1615574101371"
     v3.job.titus.netflix.com/id: "a318b9eb-50bf-4927-a9eb-b3d5a757f364"
     v3.job.titus.netflix.com/type: SERVICE
     # to be removed once VK supports the full pod spec
     pod.titus.netflix.com/container-info: "<base64 containerInfo>"
     v3.job.titus.netflix.com/descriptor: "<base64 encoded, gzipped job descriptor>"
+    pod.titus.netflix.com/entrypoint-shell-splitting-enabled: "true"
+    pod.titus.netflix.com/user-env-vars-start-index: "12"
 
     # networking - used by the Titus CNI
 

--- a/pod/config.go
+++ b/pod/config.go
@@ -68,6 +68,7 @@ type Config struct {
 	SubnetIDs                *[]string
 	TaskID                   *string
 	TTYEnabled               *bool
+	UserEnvVarsStartIndex    *uint32
 }
 
 // Sidecar represents a sidecar that's configured to run as part of the container

--- a/pod/config_test.go
+++ b/pod/config_test.go
@@ -137,9 +137,10 @@ func TestParsePod(t *testing.T) {
 		AnnotationKeyPodTitusEntrypointShellSplitting: "true",
 
 		// ints
-		AnnotationKeyPodSchemaVersion:       "2",
-		AnnotationKeyJobAcceptedTimestampMs: "1602201163007",
-		AnnotationKeyPodOomScoreAdj:         "-800",
+		AnnotationKeyPodSchemaVersion:              "2",
+		AnnotationKeyJobAcceptedTimestampMs:        "1602201163007",
+		AnnotationKeyPodOomScoreAdj:                "-800",
+		AnnotationKeyPodTitusUserEnvVarsStartIndex: "4",
 
 		// resource values
 		AnnotationKeyEgressBandwidth:  "10M",
@@ -222,6 +223,7 @@ func TestParsePod(t *testing.T) {
 		SubnetIDs:              &subnetIDs,
 		TaskID:                 ptr.StringPtr("task-id-in-label"),
 		TTYEnabled:             ptr.BoolPtr(true),
+		UserEnvVarsStartIndex:  uint32Ptr(4),
 	}
 	assert.DeepEqual(t, expConf, *conf)
 }
@@ -248,6 +250,12 @@ func TestParsePodInvalid(t *testing.T) {
 				AnnotationKeyPodSchemaVersion: "-2",
 			},
 			errMatch: "annotation is not a valid uint32 value: " + AnnotationKeyPodSchemaVersion,
+		},
+		{
+			annotations: map[string]string{
+				AnnotationKeyPodTitusUserEnvVarsStartIndex: "-2",
+			},
+			errMatch: "annotation is not a valid uint32 value: " + AnnotationKeyPodTitusUserEnvVarsStartIndex,
 		},
 		{
 			annotations: map[string]string{


### PR DESCRIPTION
This allows us to properly populate the Metatron task-identity endpointwithout needing to include the ContainerInfo annotation (which splits out Titus-specified and user-specified env vars).