### PR TITLE
Added a new platform sidecar annotation

### DIFF
--- a/pod/annotations.go
+++ b/pod/annotations.go
@@ -139,6 +139,11 @@ const (
 	AnnotationKeyPodSeccompAgentNetEnabled  = "pod.netflix.com/seccomp-agent-net-enabled"
 	AnnotationKeyPodSeccompAgentPerfEnabled = "pod.netflix.com/seccomp-agent-perf-enabled"
 
+	// container annotations (specified on a pod about a container)
+	// Specific containers indicate they want to set something by appending
+	// a prefix key with their container name.
+	AnnotationKeyPrefixContainerTypePlatformSidecar = "type.container.netflix.com/"
+
 	// logging config
 
 	AnnotationKeyLogKeepLocalFile       = "log.netflix.com/keep-local-file-after-upload"


### PR DESCRIPTION
This new annotation prefix will be used to indicate to the executor
which containers are to be treated like platform sidecars (indicating
they should be launched before user workloads, and perhaps have different
ordering and failure modes).

Annotation are per-pod, so this is a "prefix". Individual *containers*
would add an annotation to the pod like this:

```
annotations:
  type.container.netflix.com/envoy: platform
containers:
  - name: envoy
  ...
```