### PR TITLE
Made PlatformSidecar a first-class thing in pod-common

### DIFF
--- a/pod/annotations.go
+++ b/pod/annotations.go
@@ -143,6 +143,7 @@ const (
 	// Specific containers indicate they want to set something by appending
 	// a prefix key with their container name.
 	AnnotationKeyPrefixContainerTypePlatformSidecar = "type.container.netflix.com/"
+	AnnotationValueContainerTypePlatformSidecar     = "PlatformSidecar"
 
 	// logging config
 
@@ -573,4 +574,12 @@ func PodSchemaVersion(pod *corev1.Pod) (uint32, error) {
 	}
 
 	return uint32(parsedVal), nil
+}
+
+// IsPlatformSidecarContainer takes a container name and pod object,
+// and can tell you if a particular container is a Platform Sidecar
+func IsPlatformSidecarContainer(name string, pod *corev1.Pod) bool {
+	containerTypeAnnotation := AnnotationKeyPrefixContainerTypePlatformSidecar + name
+	value := pod.Annotations[containerTypeAnnotation]
+	return value == AnnotationValueContainerTypePlatformSidecar
 }

--- a/pod/annotations_test.go
+++ b/pod/annotations_test.go
@@ -51,3 +51,24 @@ func TestBadPodSchemaVersion(t *testing.T) {
 	_, err := PodSchemaVersion(pod)
 	assert.ErrorContains(t, err, "annotation is not a valid uint32 value: "+AnnotationKeyPodSchemaVersion)
 }
+
+func TestPodPlatformSidecars(t *testing.T) {
+	platformSidecarContainer := corev1.Container{Name: "im-a-platform-sidecar"}
+	userContainer := corev1.Container{Name: "im-a-user-container"}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+			Annotations: map[string]string{
+				AnnotationKeyPrefixContainerTypePlatformSidecar + "im-a-platform-sidecar": AnnotationValueContainerTypePlatformSidecar,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{platformSidecarContainer, userContainer},
+		},
+	}
+
+	assert.Equal(t, IsPlatformSidecarContainer("im-a-platform-sidecar", pod), true)
+	assert.Equal(t, IsPlatformSidecarContainer("im-a-user-container", pod), false)
+}


### PR DESCRIPTION
I need something like this so that both the producer (things mutated by the webhook) and the consumer (titus-executor) are using the exact same code for detecting which containers are considered platform sidecars, and therefore should launch first.

Complements https://github.com/Netflix/titus-executor/pull/621/files