### PR TITLE
pod spec v1: change env vars ordering so user env vars come first

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,5 +21,6 @@ require (
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.19.10
 	k8s.io/apimachinery v0.19.10
+	k8s.io/klog/v2 v2.2.0 // indirect
 	k8s.io/utils v0.0.0-20200912215256-4140de9c8800
 )

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,7 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
+github.com/go-logr/logr v0.2.0 h1:QvGt2nLcHH0WK9orKa+ppBPAxREcH364nPUedEpK0TY=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+35s3my2LFTysnkMfxsJBAMHj/DoqoB9knIWoYG/Vk0=
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=

--- a/pod/annotations.go
+++ b/pod/annotations.go
@@ -75,8 +75,8 @@ const (
 	AnnotationKeyPodTitusContainerInfo = "pod.titus.netflix.com/container-info"
 	// AnnotationKeyPodTitusEntrypointShellSplitting tells the executor to preserve the legacy shell splitting behaviour
 	AnnotationKeyPodTitusEntrypointShellSplitting = "pod.titus.netflix.com/entrypoint-shell-splitting-enabled"
-	// AnnotationKeyPodTitusUserEnvVarsStartIndex tells the executor what index the user-specified environment variables start at
-	AnnotationKeyPodTitusUserEnvVarsStartIndex = "pod.titus.netflix.com/user-env-vars-start-index"
+	// AnnotationKeyPodTitusUserEnvVarsStartIndex tells the executor what index the system-specified environment variables start at
+	AnnotationKeyPodTitusSystemEnvVarsStartIndex = "pod.titus.netflix.com/system-env-vars-start-index"
 
 	// networking - used by the Titus CNI
 
@@ -369,8 +369,8 @@ func parseAnnotations(pod *corev1.Pod, pConf *Config) error {
 			field: &pConf.PodSchemaVersion,
 		},
 		{
-			key:   AnnotationKeyPodTitusUserEnvVarsStartIndex,
-			field: &pConf.UserEnvVarsStartIndex,
+			key:   AnnotationKeyPodTitusSystemEnvVarsStartIndex,
+			field: &pConf.SystemEnvVarsStartIndex,
 		},
 	}
 

--- a/pod/annotations.go
+++ b/pod/annotations.go
@@ -75,8 +75,8 @@ const (
 	AnnotationKeyPodTitusContainerInfo = "pod.titus.netflix.com/container-info"
 	// AnnotationKeyPodTitusEntrypointShellSplitting tells the executor to preserve the legacy shell splitting behaviour
 	AnnotationKeyPodTitusEntrypointShellSplitting = "pod.titus.netflix.com/entrypoint-shell-splitting-enabled"
-	// AnnotationKeyPodTitusUserEnvVarsStartIndex tells the executor what index the system-specified environment variables start at
-	AnnotationKeyPodTitusSystemEnvVarsStartIndex = "pod.titus.netflix.com/system-env-vars-start-index"
+	// AnnotationKeyPodTitusSystemEnvVarNames tells the executor the names of the system-specified environment variables
+	AnnotationKeyPodTitusSystemEnvVarNames = "pod.titus.netflix.com/system-env-var-names"
 
 	// networking - used by the Titus CNI
 
@@ -368,10 +368,6 @@ func parseAnnotations(pod *corev1.Pod, pConf *Config) error {
 			key:   AnnotationKeyPodSchemaVersion,
 			field: &pConf.PodSchemaVersion,
 		},
-		{
-			key:   AnnotationKeyPodTitusSystemEnvVarsStartIndex,
-			field: &pConf.SystemEnvVarsStartIndex,
-		},
 	}
 
 	var err *multierror.Error
@@ -485,6 +481,13 @@ func parseAnnotations(pod *corev1.Pod, pConf *Config) error {
 			subIDs = append(subIDs, strings.TrimSpace(sub))
 		}
 		pConf.SubnetIDs = &subIDs
+	}
+
+	if envVal, ok := annotations[AnnotationKeyPodTitusSystemEnvVarNames]; ok {
+		envsSplit := strings.Split(strings.TrimSpace(envVal), ",")
+		for _, env := range envsSplit {
+			pConf.SystemEnvVarNames = append(pConf.SystemEnvVarNames, strings.TrimSpace(env))
+		}
 	}
 
 	if pConf.SchedPolicy != nil && *pConf.SchedPolicy != "batch" && *pConf.SchedPolicy != "idle" {

--- a/pod/config.go
+++ b/pod/config.go
@@ -58,10 +58,10 @@ type Config struct {
 	SecurityGroupIDs         *[]string
 	Sidecars                 []Sidecar
 	StaticIPAllocationUUID   *string
+	SystemEnvVarsStartIndex  *uint32
 	SubnetIDs                *[]string
 	TaskID                   *string
 	TTYEnabled               *bool
-	UserEnvVarsStartIndex    *uint32
 	WorkloadDetail           *string
 	WorkloadName             *string
 	WorkloadMetadata         *string

--- a/pod/config.go
+++ b/pod/config.go
@@ -58,7 +58,7 @@ type Config struct {
 	SecurityGroupIDs         *[]string
 	Sidecars                 []Sidecar
 	StaticIPAllocationUUID   *string
-	SystemEnvVarsStartIndex  *uint32
+	SystemEnvVarNames        []string
 	SubnetIDs                *[]string
 	TaskID                   *string
 	TTYEnabled               *bool

--- a/pod/config_test.go
+++ b/pod/config_test.go
@@ -137,10 +137,10 @@ func TestParsePod(t *testing.T) {
 		AnnotationKeyPodTitusEntrypointShellSplitting: "true",
 
 		// ints
-		AnnotationKeyPodSchemaVersion:              "2",
-		AnnotationKeyJobAcceptedTimestampMs:        "1602201163007",
-		AnnotationKeyPodOomScoreAdj:                "-800",
-		AnnotationKeyPodTitusUserEnvVarsStartIndex: "4",
+		AnnotationKeyPodSchemaVersion:                "2",
+		AnnotationKeyJobAcceptedTimestampMs:          "1602201163007",
+		AnnotationKeyPodOomScoreAdj:                  "-800",
+		AnnotationKeyPodTitusSystemEnvVarsStartIndex: "4",
 
 		// resource values
 		AnnotationKeyEgressBandwidth:  "10M",
@@ -219,11 +219,11 @@ func TestParsePod(t *testing.T) {
 		Sidecars: []Sidecar{
 			{Name: "servicemesh", Enabled: true, Image: "titusops/servicemesh:latest", Version: 2},
 		},
-		StaticIPAllocationUUID: ptr.StringPtr("static-ip-alloc-id"),
-		SubnetIDs:              &subnetIDs,
-		TaskID:                 ptr.StringPtr("task-id-in-label"),
-		TTYEnabled:             ptr.BoolPtr(true),
-		UserEnvVarsStartIndex:  uint32Ptr(4),
+		StaticIPAllocationUUID:  ptr.StringPtr("static-ip-alloc-id"),
+		SubnetIDs:               &subnetIDs,
+		SystemEnvVarsStartIndex: uint32Ptr(4),
+		TaskID:                  ptr.StringPtr("task-id-in-label"),
+		TTYEnabled:              ptr.BoolPtr(true),
 	}
 	assert.DeepEqual(t, expConf, *conf)
 }
@@ -253,9 +253,9 @@ func TestParsePodInvalid(t *testing.T) {
 		},
 		{
 			annotations: map[string]string{
-				AnnotationKeyPodTitusUserEnvVarsStartIndex: "-2",
+				AnnotationKeyPodTitusSystemEnvVarsStartIndex: "-2",
 			},
-			errMatch: "annotation is not a valid uint32 value: " + AnnotationKeyPodTitusUserEnvVarsStartIndex,
+			errMatch: "annotation is not a valid uint32 value: " + AnnotationKeyPodTitusSystemEnvVarsStartIndex,
 		},
 		{
 			annotations: map[string]string{

--- a/pod/config_test.go
+++ b/pod/config_test.go
@@ -101,6 +101,7 @@ func TestParsePod(t *testing.T) {
 		AnnotationKeyNetworkSecurityGroups:         "sg-1 , sg-2 ",
 		AnnotationKeyNetworkStaticIPAllocationUUID: "static-ip-alloc-id",
 		AnnotationKeyNetworkSubnetIDs:              "subnet-1 , subnet-2 ",
+		AnnotationKeyPodTitusSystemEnvVarNames:     "SYSTEM1 , SYSTEM2 ",
 
 		// We don't parse these right now - including them so that
 		// tests fail if we do start parsing them or remove them
@@ -137,10 +138,9 @@ func TestParsePod(t *testing.T) {
 		AnnotationKeyPodTitusEntrypointShellSplitting: "true",
 
 		// ints
-		AnnotationKeyPodSchemaVersion:                "2",
-		AnnotationKeyJobAcceptedTimestampMs:          "1602201163007",
-		AnnotationKeyPodOomScoreAdj:                  "-800",
-		AnnotationKeyPodTitusSystemEnvVarsStartIndex: "4",
+		AnnotationKeyPodSchemaVersion:       "2",
+		AnnotationKeyJobAcceptedTimestampMs: "1602201163007",
+		AnnotationKeyPodOomScoreAdj:         "-800",
 
 		// resource values
 		AnnotationKeyEgressBandwidth:  "10M",
@@ -219,11 +219,11 @@ func TestParsePod(t *testing.T) {
 		Sidecars: []Sidecar{
 			{Name: "servicemesh", Enabled: true, Image: "titusops/servicemesh:latest", Version: 2},
 		},
-		StaticIPAllocationUUID:  ptr.StringPtr("static-ip-alloc-id"),
-		SubnetIDs:               &subnetIDs,
-		SystemEnvVarsStartIndex: uint32Ptr(4),
-		TaskID:                  ptr.StringPtr("task-id-in-label"),
-		TTYEnabled:              ptr.BoolPtr(true),
+		StaticIPAllocationUUID: ptr.StringPtr("static-ip-alloc-id"),
+		SubnetIDs:              &subnetIDs,
+		SystemEnvVarNames:      []string{"SYSTEM1", "SYSTEM2"},
+		TaskID:                 ptr.StringPtr("task-id-in-label"),
+		TTYEnabled:             ptr.BoolPtr(true),
 	}
 	assert.DeepEqual(t, expConf, *conf)
 }
@@ -250,12 +250,6 @@ func TestParsePodInvalid(t *testing.T) {
 				AnnotationKeyPodSchemaVersion: "-2",
 			},
 			errMatch: "annotation is not a valid uint32 value: " + AnnotationKeyPodSchemaVersion,
-		},
-		{
-			annotations: map[string]string{
-				AnnotationKeyPodTitusSystemEnvVarsStartIndex: "-2",
-			},
-			errMatch: "annotation is not a valid uint32 value: " + AnnotationKeyPodTitusSystemEnvVarsStartIndex,
 		},
 		{
 			annotations: map[string]string{


### PR DESCRIPTION
When a pod is launched on VK, it does some processing on the env vars (in order to duplicate RK's behaviour), which includes dedup'ing them.  To do this dedup'ing, it stores the env vars in a `map[string]string`, and then creates a new EnvVar slice from that map.  This means that in VK, you can't depend on any specific ordering of env vars.  To work around this so that Metatron knows which are system-specified versus user, we're listing which env vars injected by the system in an annotation.

This does mean that the webhook will need to update this annotation if it adds new env vars - we should add a `addEnvVarToContainer` function or the like so that this isn't error-prone.