### PR TITLE
Parse platform sidecar annotations in titus-kube-common

### DIFF
--- a/pod/annotations.go
+++ b/pod/annotations.go
@@ -617,16 +617,6 @@ func LegacySidecarAnnotation(sidecarName, suffix string) string {
 	return fmt.Sprintf("%s.%s/%s", AnnotationKeyPrefixSidecarsLegacy, sidecarName, suffix)
 }
 
-// SidecarAnnotations returns both current and legacy forms of an annotation key
-// referencing a particular sidecar.
-// TODO(aaronl): Remove this once we've fully transitioned to the new format.
-func SidecarAnnotations(sidecarName, suffix string) []string {
-	return []string{
-		SidecarAnnotation(sidecarName, suffix),
-		LegacySidecarAnnotation(sidecarName, suffix),
-	}
-}
-
 type PlatformSidecar struct {
 	Name     string
 	Channel  string
@@ -657,7 +647,10 @@ func PlatformSidecars(annotations map[string]string) []PlatformSidecar {
 			Name:    sidecarName,
 			Channel: "default",
 		}
-		for _, key := range SidecarAnnotations(sidecarName, "channel") {
+		for _, key := range []string{
+			SidecarAnnotation(sidecarName, "channel"),
+			LegacySidecarAnnotation(sidecarName, "channel"),
+		} {
 			if channel, ok := annotations[key]; ok {
 				sidecar.Channel = channel
 				break

--- a/pod/annotations.go
+++ b/pod/annotations.go
@@ -626,3 +626,54 @@ func SidecarAnnotations(sidecarName, suffix string) []string {
 		LegacySidecarAnnotation(sidecarName, suffix),
 	}
 }
+
+type PlatformSidecar struct {
+	Name     string
+	Channel  string
+	ArgsJSON []byte
+}
+
+// PlatformSidecars parses sidecar-related annotations and returns a structured
+// slice of platform sidecars.
+func PlatformSidecars(annotations map[string]string) []PlatformSidecar {
+	// Look for legacy include annotation
+	var sidecarNames []string
+	if sidecarList := annotations[AnnotationKeySidecarsIncludeLegacy]; sidecarList != "" {
+		sidecarNames = strings.Split(sidecarList, " ")
+	}
+
+	// Handle the current include annotation format
+	for a, val := range annotations {
+		if strings.HasSuffix(a, "."+AnnotationKeySuffixSidecars) {
+			if boolVal, _ := strconv.ParseBool(val); boolVal {
+				sidecarNames = append(sidecarNames, strings.TrimSuffix(a, "."+AnnotationKeySuffixSidecars))
+			}
+		}
+	}
+
+	var sidecars []PlatformSidecar
+	for _, sidecarName := range sidecarNames {
+		sidecar := PlatformSidecar{
+			Name:    sidecarName,
+			Channel: "default",
+		}
+		for _, key := range SidecarAnnotations(sidecarName, "channel") {
+			if channel, ok := annotations[key]; ok {
+				sidecar.Channel = channel
+				break
+			}
+		}
+
+		for _, key := range []string{
+			SidecarAnnotation(sidecarName, "arguments"),
+			LegacySidecarAnnotation(sidecarName, "args"),
+		} {
+			if args, ok := annotations[key]; ok {
+				sidecar.ArgsJSON = []byte(args)
+			}
+		}
+
+		sidecars = append(sidecars, sidecar)
+	}
+	return sidecars
+}


### PR DESCRIPTION
Add a small layer of abstraction that parses annotations, so
platform-sidecar-mutator only needs to deal with structured data and
doesn't have to concern itself with the structure of the annotations.