### PR TITLE
Add annotation key for platform sidecar version

### DIFF
--- a/pod/annotations.go
+++ b/pod/annotations.go
@@ -166,7 +166,7 @@ const (
 	AnnotationKeyPrefixSidecarsLegacy                = "titusParameter.agent.sidecars"
 	AnnotationKeySuffixSidecarsChannelOverride       = "channel-override"
 	AnnotationKeySuffixSidecarsChannelOverrideReason = "channel-override-reason"
-	AnnotationKeySuffixSidecarsVersion               = "version"
+	AnnotationKeySuffixSidecarsRelease               = "release" // release = $channel/$version
 	AnnotationKeySidecarsIncludeLegacy               = AnnotationKeyPrefixSidecarsLegacy + "/include"
 )
 

--- a/pod/annotations.go
+++ b/pod/annotations.go
@@ -166,6 +166,7 @@ const (
 	AnnotationKeyPrefixSidecarsLegacy                = "titusParameter.agent.sidecars"
 	AnnotationKeySuffixSidecarsChannelOverride       = "channel-override"
 	AnnotationKeySuffixSidecarsChannelOverrideReason = "channel-override-reason"
+	AnnotationKeySuffixSidecarsVersion               = "version"
 	AnnotationKeySidecarsIncludeLegacy               = AnnotationKeyPrefixSidecarsLegacy + "/include"
 )
 


### PR DESCRIPTION
This PR enables us adding the version annotation for each sidecar, so it can be queried from Titus.