### PR TITLE
Add platform sidecar name in a container annotation

### DIFF
--- a/pod/annotations.go
+++ b/pod/annotations.go
@@ -141,9 +141,9 @@ const (
 
 	// container annotations (specified on a pod about a container)
 	// Specific containers indicate they want to set something by appending
-	// a prefix key with their container name.
-	AnnotationKeyPrefixContainerType            = "type.container.netflix.com/"
-	AnnotationValueContainerTypePlatformSidecar = "PlatformSidecar"
+	// a prefix key with their container name ($name.containers.netflix.com).
+	AnnotationKeySuffixContainers        = "containers.netflix.com"
+	AnnotationKeySuffixContainersSidecar = "platform-sidecar"
 
 	// logging config
 
@@ -598,12 +598,17 @@ func PodSchemaVersion(pod *corev1.Pod) (uint32, error) {
 	return uint32(parsedVal), nil
 }
 
+// ContainerAnnotation forms an annotation key referencing a particular container.
+func ContainerAnnotation(containerName, suffix string) string {
+	return fmt.Sprintf("%s.%s/%s", containerName, AnnotationKeySuffixContainers, suffix)
+}
+
 // IsPlatformSidecarContainer takes a container name and pod object,
 // and can tell you if a particular container is a Platform Sidecar
 func IsPlatformSidecarContainer(name string, pod *corev1.Pod) bool {
-	containerTypeAnnotation := AnnotationKeyPrefixContainerType + name
-	value := pod.Annotations[containerTypeAnnotation]
-	return value == AnnotationValueContainerTypePlatformSidecar
+	platformSidecarAnnotation := ContainerAnnotation(name, AnnotationKeySuffixContainersSidecar)
+	_, ok := pod.Annotations[platformSidecarAnnotation]
+	return ok
 }
 
 // SidecarAnnotation forms an annotation key referencing a particular sidecar.

--- a/pod/annotations_test.go
+++ b/pod/annotations_test.go
@@ -61,7 +61,7 @@ func TestPodPlatformSidecars(t *testing.T) {
 			Name:      "foo",
 			Namespace: "default",
 			Annotations: map[string]string{
-				AnnotationKeyPrefixContainerType + "im-a-platform-sidecar": AnnotationValueContainerTypePlatformSidecar,
+				ContainerAnnotation("im-a-platform-sidecar", AnnotationKeySuffixContainersSidecar): "bar",
 			},
 		},
 		Spec: corev1.PodSpec{


### PR DESCRIPTION
Titus UI can use this annotation to tell if a container is added by a platform sidecar, and link the container to the platform sidecar that added it.