### PR TITLE
Add pod scheduling requirements annotations

### DIFF
--- a/pod/annotations.go
+++ b/pod/annotations.go
@@ -170,10 +170,10 @@ const (
 	AnnotationKeySidecarsIncludeLegacy               = AnnotationKeyPrefixSidecarsLegacy + "/include"
 
 	// scheduling soft SLAs
-	AnnotationKeySchedLatencyReq      = "scheduler.titus.netflix.com/sched-latency-req"
+	AnnotationKeySchedLatencyReq      = "scheduler.titus.netflix.com/sched-latency-req" // priority handling in scheduling queue
 	AnnotationValSchedLatencyDelay    = "delay"
 	AnnotationValSchedLatencyFast     = "fast"
-	AnnotationKeySchedSpreadingReq    = "scheduler.titus.netflix.com/spreading-req"
+	AnnotationKeySchedSpreadingReq    = "scheduler.titus.netflix.com/spreading-req" // dynamic spreading behavior
 	AnnotationValSchedSpreadingPack   = "pack"
 	AnnotationValSchedSpreadingSpread = "spread"
 )

--- a/pod/annotations.go
+++ b/pod/annotations.go
@@ -168,6 +168,14 @@ const (
 	AnnotationKeySuffixSidecarsChannelOverrideReason = "channel-override-reason"
 	AnnotationKeySuffixSidecarsRelease               = "release" // release = $channel/$version
 	AnnotationKeySidecarsIncludeLegacy               = AnnotationKeyPrefixSidecarsLegacy + "/include"
+
+	// scheduling soft SLAs
+	AnnotationKeySchedLatencyReq      = "scheduler.titus.netflix.com/sched-latency-req"
+	AnnotationValSchedLatencyDelay    = "delay"
+	AnnotationValSchedLatencyFast     = "fast"
+	AnnotationKeySchedSpreadingReq    = "scheduler.titus.netflix.com/spreading-req"
+	AnnotationValSchedSpreadingPack   = "pack"
+	AnnotationValSchedSpreadingSpread = "spread"
 )
 
 func validateImage(image string) error {


### PR DESCRIPTION
Will be used in mixed scheduling for:
- priority handling in scheduling queue (`scheduler.titus.netflix.com/sched-latency-req`)
- dynamic spreading behavior in upcoming plugin (`scheduler.titus.netflix.com/spreading-req`)