### PR TITLE
Added image tag annotation for v1 schema pods

### DIFF
--- a/pod/annotations.go
+++ b/pod/annotations.go
@@ -77,6 +77,9 @@ const (
 	AnnotationKeyPodTitusEntrypointShellSplitting = "pod.titus.netflix.com/entrypoint-shell-splitting-enabled"
 	// AnnotationKeyPodTitusSystemEnvVarNames tells the executor the names of the system-specified environment variables
 	AnnotationKeyPodTitusSystemEnvVarNames = "pod.titus.netflix.com/system-env-var-names"
+	// AnnotationKeyImageTagPrefix stores the original tag for the an image.
+	// This is because on the v1 pod image field, there is only room for the digest and no room for the tag it came from
+	AnnotationKeyImageTagPrefix = "pod.titus.netflix.com/image-tag-"
 
 	// networking - used by the Titus CNI
 	AnnotationKeySubnetsLegacy             = "network.titus.netflix.com/subnets"

--- a/pod/config_test.go
+++ b/pod/config_test.go
@@ -87,6 +87,7 @@ func TestParsePod(t *testing.T) {
 		AnnotationKeyJobType:                       "BATCH",
 		AnnotationKeyJobDescriptor:                 "myjobdesc",
 		AnnotationKeyPodTitusContainerInfo:         "cinfo",
+		AnnotationKeyImageTagPrefix + "main":       "testTag",
 		AnnotationKeyWorkloadDetail:                "mydetail",
 		AnnotationKeyWorkloadName:                  "myapp",
 		AnnotationKeyWorkloadOwnerEmail:            "test@example.com",
@@ -227,6 +228,7 @@ func TestParsePod(t *testing.T) {
 		TTYEnabled:             ptr.BoolPtr(true),
 	}
 	assert.DeepEqual(t, expConf, *conf)
+	assert.Equal(t, GetImageTagForContainer("main", pod), "testTag")
 }
 
 func TestParsePodInvalid(t *testing.T) {

--- a/pod/containers.go
+++ b/pod/containers.go
@@ -30,3 +30,12 @@ func GetContainerByName(pod *corev1.Pod, name string) *corev1.Container {
 
 	return nil
 }
+
+// GetImageTagForContainer looks up the original tag that was used to create
+// the image string in the Container Spec.
+// It may return an empty string if there was no tag, or if it was missing
+func GetImageTagForContainer(cName string, pod *corev1.Pod) string {
+	key := AnnotationKeyImageTagPrefix + cName
+	value := pod.ObjectMeta.Annotations[key]
+	return value
+}


### PR DESCRIPTION
We need to know the original Tag that was used for container
images for security purposes.

This new annotation allows us to set and get that original tag
on the pod, so that later when we go to verify that pods sig
against what was originally submitted to titus (the tag), we
can verify.

----

If shipit, I'll make the control plane set this annotation when creating v1 pods, and have the titus-executor get this annotation when creating the faux cInfo for metatron verification purposes.
(currently the faux cInfo always returns "latest", no matter what)