### PR TITLE
Removed legacy platform sidecar annotation method

### DIFF
--- a/pod/annotations_test.go
+++ b/pod/annotations_test.go
@@ -3,7 +3,7 @@ package pod
 import (
 	"testing"
 
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -20,7 +20,7 @@ func TestPodSchemaVersion(t *testing.T) {
 	}
 
 	ver, err := PodSchemaVersion(pod)
-	assert.NilError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(5), ver)
 }
 
@@ -33,7 +33,7 @@ func TestPodSchemaVersionUnset(t *testing.T) {
 	}
 
 	ver, err := PodSchemaVersion(pod)
-	assert.NilError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(0), ver)
 }
 
@@ -49,7 +49,7 @@ func TestBadPodSchemaVersion(t *testing.T) {
 	}
 
 	_, err := PodSchemaVersion(pod)
-	assert.ErrorContains(t, err, "annotation is not a valid uint32 value: "+AnnotationKeyPodSchemaVersion)
+	assert.EqualError(t, err, "annotation is not a valid uint32 value: "+AnnotationKeyPodSchemaVersion)
 }
 
 func TestPodPlatformSidecars(t *testing.T) {
@@ -71,4 +71,27 @@ func TestPodPlatformSidecars(t *testing.T) {
 
 	assert.Equal(t, IsPlatformSidecarContainer("im-a-platform-sidecar", pod), true)
 	assert.Equal(t, IsPlatformSidecarContainer("im-a-user-container", pod), false)
+}
+
+func TestGetPlatformSidecars(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "podName",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"foo." + AnnotationKeySuffixSidecars:  "true",
+				SidecarAnnotation("foo", "channel"):   "bar",
+				SidecarAnnotation("foo", "arguments"): "args",
+			},
+		},
+	}
+	actual := PlatformSidecars(pod.Annotations)
+	expected := []PlatformSidecar{
+		{
+			Name:     "foo",
+			Channel:  "bar",
+			ArgsJSON: []byte("args"),
+		},
+	}
+	assert.Equal(t, actual, expected)
 }


### PR DESCRIPTION
This should only be shipped once we are not using it.