### PR TITLE
Added new InjectedEnvVarName pod config for metatron TITUS-5821

### DIFF
--- a/pod/annotations.go
+++ b/pod/annotations.go
@@ -77,6 +77,9 @@ const (
 	AnnotationKeyPodTitusEntrypointShellSplitting = "pod.titus.netflix.com/entrypoint-shell-splitting-enabled"
 	// AnnotationKeyPodTitusSystemEnvVarNames tells the executor the names of the system-specified environment variables
 	AnnotationKeyPodTitusSystemEnvVarNames = "pod.titus.netflix.com/system-env-var-names"
+	// AnnotationKeyPodInjectedEnvVarNames tells the executor the names of the externally-injected environment variables,
+	// which neither come from the user nor titus itself, and should be ignored for identify verification purposes
+	AnnotationKeyPodInjectedEnvVarNames = "pod.titus.netflix.com/injected-env-var-names"
 	// AnnotationKeyImageTagPrefix stores the original tag for the an image.
 	// This is because on the v1 pod image field, there is only room for the digest and no room for the tag it came from
 	AnnotationKeyImageTagPrefix = "pod.titus.netflix.com/image-tag-"
@@ -511,6 +514,13 @@ func parseAnnotations(pod *corev1.Pod, pConf *Config) error {
 		envsSplit := strings.Split(strings.TrimSpace(envVal), ",")
 		for _, env := range envsSplit {
 			pConf.SystemEnvVarNames = append(pConf.SystemEnvVarNames, strings.TrimSpace(env))
+		}
+	}
+
+	if envVal, ok := annotations[AnnotationKeyPodInjectedEnvVarNames]; ok {
+		envsSplit := strings.Split(strings.TrimSpace(envVal), ",")
+		for _, env := range envsSplit {
+			pConf.InjectedEnvVarNames = append(pConf.InjectedEnvVarNames, strings.TrimSpace(env))
 		}
 	}
 

--- a/pod/config.go
+++ b/pod/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	FuseEnabled              *bool
 	HostnameStyle            *string
 	IAMRole                  *string
+	InjectedEnvVarNames      []string
 	IngressBandwidth         *resource.Quantity
 	IMDSRequireToken         *string
 	JobAcceptedTimestampMs   *uint64

--- a/pod/config_test.go
+++ b/pod/config_test.go
@@ -104,6 +104,7 @@ func TestParsePod(t *testing.T) {
 		AnnotationKeyNetworkStaticIPAllocationUUID: "static-ip-alloc-id",
 		AnnotationKeyNetworkSubnetIDs:              "subnet-1 , subnet-2 ",
 		AnnotationKeyPodTitusSystemEnvVarNames:     "SYSTEM1 , SYSTEM2 ",
+		AnnotationKeyPodInjectedEnvVarNames:        "MUTATED1 , MUTATED2 ",
 
 		// We don't parse these right now - including them so that
 		// tests fail if we do start parsing them or remove them
@@ -224,6 +225,7 @@ func TestParsePod(t *testing.T) {
 		StaticIPAllocationUUID: ptr.StringPtr("static-ip-alloc-id"),
 		SubnetIDs:              &subnetIDs,
 		SystemEnvVarNames:      []string{"SYSTEM1", "SYSTEM2"},
+		InjectedEnvVarNames:    []string{"MUTATED1", "MUTATED2"},
 		TaskID:                 ptr.StringPtr("task-id-in-label"),
 		TTYEnabled:             ptr.BoolPtr(true),
 	}


### PR DESCRIPTION
For identity purposes, we need a way to distinguish between user-defined
env vars, titus-defined env vars, and the new *injected* env vars.

These injected env vars come from the new platform sidecar mutation
code, which has the power to inject env variables into the *users* containers
(not just the sidecars).

This conflicts with metatron verification, because now it sees this
extra var from nowhere!

This adds a new annotation so the mutator and add to it, and then
the titus-executor and ignore these vars.

This change kinda assumes (safely for now) that the list of vars
is evenly applied to all user containers (usually just the main one).
It could get messy if we ever want to add some env vars to some user
containers but not others? But for now I don't think we should do that.