### PR TITLE
Made the pod parsing annotation errors easier to understand

### DIFF
--- a/pod/annotations.go
+++ b/pod/annotations.go
@@ -408,7 +408,7 @@ func parseAnnotations(pod *corev1.Pod, pConf *Config) error {
 
 	if hostnameStyle, ok := annotations[AnnotationKeyPodHostnameStyle]; ok {
 		if hostnameStyle != "ec2" && hostnameStyle != "" {
-			err = multierror.Append(err, fmt.Errorf("annotation is not a valid hostname style: %s", AnnotationKeyPodHostnameStyle))
+			err = multierror.Append(err, fmt.Errorf("%s annotation is not a valid hostname style: %s", AnnotationKeyPodHostnameStyle, hostnameStyle))
 		}
 	}
 
@@ -419,7 +419,7 @@ func parseAnnotations(pod *corev1.Pod, pConf *Config) error {
 			if pErr == nil {
 				*an.field = &boolVal
 			} else {
-				err = multierror.Append(err, fmt.Errorf("annotation is not a valid boolean value: %s", an.key))
+				err = multierror.Append(err, fmt.Errorf("%s annotation is not a valid boolean value %s: %w", an.key, val, pErr))
 			}
 		}
 	}
@@ -432,7 +432,7 @@ func parseAnnotations(pod *corev1.Pod, pConf *Config) error {
 				parsedUint32 := uint32(parsedVal)
 				*an.field = &parsedUint32
 			} else {
-				err = multierror.Append(err, fmt.Errorf("annotation is not a valid uint32 value: %s", an.key))
+				err = multierror.Append(err, fmt.Errorf("%s annotation is not a valid uint32 value %s: %w", an.key, val, pErr))
 			}
 		}
 	}
@@ -444,7 +444,7 @@ func parseAnnotations(pod *corev1.Pod, pConf *Config) error {
 			parsedUint64 := uint64(parsedVal)
 			pConf.JobAcceptedTimestampMs = &parsedUint64
 		} else {
-			err = multierror.Append(err, fmt.Errorf("annotation is not a valid uint64 value: %s", AnnotationKeyJobAcceptedTimestampMs))
+			err = multierror.Append(err, fmt.Errorf("%s annotation is not a valid uint64 value %s: %w", AnnotationKeyJobAcceptedTimestampMs, val, pErr))
 		}
 	}
 
@@ -455,7 +455,7 @@ func parseAnnotations(pod *corev1.Pod, pConf *Config) error {
 			parsedInt32 := int32(parsedVal)
 			pConf.OomScoreAdj = &parsedInt32
 		} else {
-			err = multierror.Append(err, fmt.Errorf("annotation is not a valid int32 value: %s", AnnotationKeyPodOomScoreAdj))
+			err = multierror.Append(err, fmt.Errorf("%s annotation is not a valid int32 value %s: %w", AnnotationKeyPodOomScoreAdj, val, pErr))
 		}
 	}
 
@@ -466,7 +466,7 @@ func parseAnnotations(pod *corev1.Pod, pConf *Config) error {
 			if pErr == nil {
 				*an.field = &resVal
 			} else {
-				err = multierror.Append(err, fmt.Errorf("annotation is not a valid resource value: %s", an.key))
+				err = multierror.Append(err, fmt.Errorf("%s annotation is not a valid resource value %s: %w", an.key, &resVal, pErr))
 			}
 		}
 	}
@@ -478,7 +478,7 @@ func parseAnnotations(pod *corev1.Pod, pConf *Config) error {
 			if pErr == nil {
 				*an.field = &durVal
 			} else {
-				err = multierror.Append(err, fmt.Errorf("annotation is not a valid duration value: %s", an.key))
+				err = multierror.Append(err, fmt.Errorf("%s annotation is not a valid duration value %s: %w", an.key, durVal, pErr))
 			}
 		}
 	}
@@ -488,7 +488,7 @@ func parseAnnotations(pod *corev1.Pod, pConf *Config) error {
 		if pErr == nil {
 			pConf.LogUploadRegExp = uploadRegexp
 		} else {
-			err = multierror.Append(err, fmt.Errorf("annotation is not a valid regexp value: %s: %w", AnnotationKeyLogUploadRegexp, pErr))
+			err = multierror.Append(err, fmt.Errorf("%s annotation is not a valid regexp value %s:  %w", uploadRegexpVal, AnnotationKeyLogUploadRegexp, pErr))
 		}
 	}
 
@@ -525,7 +525,7 @@ func parseAnnotations(pod *corev1.Pod, pConf *Config) error {
 	}
 
 	if pConf.SchedPolicy != nil && *pConf.SchedPolicy != "batch" && *pConf.SchedPolicy != "idle" {
-		err = multierror.Append(err, fmt.Errorf("annotation is not a valid scheduler policy: %s", AnnotationKeyPodSchedPolicy))
+		err = multierror.Append(err, fmt.Errorf("%s annotation is not a valid scheduler policy: %s", AnnotationKeyPodSchedPolicy, *pConf.SchedPolicy))
 	}
 
 	if sErr := parseServiceAnnotations(annotations, pConf); sErr != nil {
@@ -562,7 +562,7 @@ func parseServiceAnnotations(annotations map[string]string, pConf *Config) error
 		if !ok {
 			vInt, vErr := strconv.Atoi(strings.TrimPrefix(version, "v"))
 			if vErr != nil {
-				err = multierror.Append(err, fmt.Errorf("annotation has an incorrect service version number: %s", k))
+				err = multierror.Append(err, fmt.Errorf("%s annotation has an incorrect service version number: %s", k, version))
 				continue
 			}
 
@@ -575,7 +575,7 @@ func parseServiceAnnotations(annotations map[string]string, pConf *Config) error
 		if param == "enabled" {
 			boolVal, pErr := strconv.ParseBool(v)
 			if pErr != nil {
-				err = multierror.Append(err, fmt.Errorf("annotation has an incorrect service enabled boolean value: %s", k))
+				err = multierror.Append(err, fmt.Errorf("%s annotation has an incorrect service enabled boolean value: %s", k, v))
 				continue
 			}
 			sc.Enabled = boolVal

--- a/pod/config_test.go
+++ b/pod/config_test.go
@@ -242,49 +242,49 @@ func TestParsePodInvalid(t *testing.T) {
 			annotations: map[string]string{
 				AnnotationKeyPodHostnameStyle: "not-ec2",
 			},
-			errMatch: "annotation is not a valid hostname style: " + AnnotationKeyPodHostnameStyle,
+			errMatch: "pod.netflix.com/hostname-style annotation is not a valid hostname style: not-ec2",
 		},
 		{
 			annotations: map[string]string{
 				AnnotationKeyLogKeepLocalFile: "yes",
 			},
-			errMatch: "annotation is not a valid boolean value: " + AnnotationKeyLogKeepLocalFile,
+			errMatch: "log.netflix.com/keep-local-file-after-upload annotation is not a valid boolean value yes: strconv.ParseBool",
 		},
 		{
 			annotations: map[string]string{
 				AnnotationKeyPodSchemaVersion: "-2",
 			},
-			errMatch: "annotation is not a valid uint32 value: " + AnnotationKeyPodSchemaVersion,
+			errMatch: "pod.netflix.com/pod-schema-version annotation is not a valid uint32 value -2: strconv.ParseUint",
 		},
 		{
 			annotations: map[string]string{
 				AnnotationKeyJobAcceptedTimestampMs: "-5",
 			},
-			errMatch: "annotation is not a valid uint64 value: " + AnnotationKeyJobAcceptedTimestampMs,
+			errMatch: "v3.job.titus.netflix.com/accepted-timestamp-ms annotation is not a valid uint64 value -5: strconv.ParseUint",
 		},
 		{
 			annotations: map[string]string{
 				AnnotationKeyPodOomScoreAdj: "foo",
 			},
-			errMatch: "annotation is not a valid int32 value: " + AnnotationKeyPodOomScoreAdj,
+			errMatch: "pod.netflix.com/oom-score-adj annotation is not a valid int32 value foo: strconv.ParseInt",
 		},
 		{
 			annotations: map[string]string{
 				AnnotationKeyEgressBandwidth: "10ZiB",
 			},
-			errMatch: "annotation is not a valid resource value: " + AnnotationKeyEgressBandwidth,
+			errMatch: "kubernetes.io/egress-bandwidth annotation is not a valid resource value 0: quantities must match the regular expression",
 		},
 		{
 			annotations: map[string]string{
 				AnnotationKeyLogStdioCheckInterval: "2yearz",
 			},
-			errMatch: "annotation is not a valid duration value: " + AnnotationKeyLogStdioCheckInterval,
+			errMatch: "log.netflix.com/stdio-check-interval annotation is not a valid duration value 0s: time: unknown unit",
 		},
 		{
 			annotations: map[string]string{
 				AnnotationKeyPodSchedPolicy: "something",
 			},
-			errMatch: "annotation is not a valid scheduler policy: " + AnnotationKeyPodSchedPolicy,
+			errMatch: "pod.netflix.com/sched-policy annotation is not a valid scheduler policy: something",
 		},
 		{
 			annotations: map[string]string{
@@ -296,13 +296,13 @@ func TestParsePodInvalid(t *testing.T) {
 			annotations: map[string]string{
 				AnnotationKeyServicePrefix + "/foo.vA.enabled": "true",
 			},
-			errMatch: "annotation has an incorrect service version number: service.netflix.com/foo.vA.enabled",
+			errMatch: "service.netflix.com/foo.vA.enabled annotation has an incorrect service version number",
 		},
 		{
 			annotations: map[string]string{
 				AnnotationKeyServicePrefix + "/foo.v1.enabled": "asdf",
 			},
-			errMatch: "annotation has an incorrect service enabled boolean value: service.netflix.com/foo.v1.enabled",
+			errMatch: "service.netflix.com/foo.v1.enabled annotation has an incorrect service enabled boolean value: asdf",
 		},
 		{
 			annotations: map[string]string{
@@ -336,7 +336,7 @@ func TestBadBoolAnnotations(t *testing.T) {
 	for _, ann := range boolAnnotations {
 		pod := buildPod(map[string]string{ann: "bad"}, map[string]string{})
 		_, err := PodToConfig(pod)
-		assert.ErrorContains(t, err, "annotation is not a valid boolean value: "+ann)
+		assert.ErrorContains(t, err, ann+" annotation is not a valid boolean value bad:")
 	}
 }
 


### PR DESCRIPTION
Previously, we were not printing what the actual annotation
value was that we were erroring on! And sometimes not even the error!

This change makes us print out the annotation key, value and error
whenever we encounter a problem for maximum debugability.

Otherwise we get errors like

    * annotation is not a valid scheduler policy: pod.netflix.com/sched-policy

Which kinda makes you think that `*` was the value? But it wasn't.