### PR TITLE
Removed older workload container function

### DIFF
--- a/pod/containers.go
+++ b/pod/containers.go
@@ -10,7 +10,6 @@ func GetMainUserContainer(pod *corev1.Pod) *corev1.Container {
 	}
 
 	// Older method where the main container's name was the taskid
-	firstContainer := pod.Spec.Containers[0]
 	for i := range pod.Spec.Containers {
 		c := &pod.Spec.Containers[i]
 		if c.Name == pod.Name {
@@ -27,7 +26,7 @@ func GetMainUserContainer(pod *corev1.Pod) *corev1.Container {
 	}
 
 	// Fallback method, whatever came first
-	return &firstContainer
+	return &pod.Spec.Containers[0]
 }
 
 func GetContainerByName(pod *corev1.Pod, name string) *corev1.Container {


### PR DESCRIPTION
Currently fighting the subtle differences between `getWorkloadContainer` and `getMainContainer`, so I'm paving them over with one function.

Consumers of titus-kube-common will break when they upgrade, but meh.