### PR TITLE
High scale network mode annotations for security groups and subnetIds

### DIFF
--- a/pod/annotations.go
+++ b/pod/annotations.go
@@ -106,6 +106,8 @@ const (
 	AnnotationKeyEffectiveNetworkMode  = "network.netflix.com/effective-network-mode"
 	AnnotationKeyNetworkSecurityGroups = "network.netflix.com/security-groups"
 	AnnotationKeyNetworkSubnetIDs      = "network.netflix.com/subnet-ids"
+	AnnotationKeyHighScaleNetworkSecurityGroups = "network.netflix.com/hs-security-groups"
+	AnnotationKeyHighScaleNetworkSubnetIDs      = "network.netflix.com/hs-subnet-ids"
 	// TODO: deprecate this in favor of using the UUID annotation below
 	AnnotationKeyNetworkStaticIPAllocationUUID = "network.netflix.com/static-ip-allocation-uuid"
 
@@ -520,6 +522,24 @@ func parseAnnotations(pod *corev1.Pod, pConf *Config) error {
 			subIDs = append(subIDs, strings.TrimSpace(sub))
 		}
 		pConf.SubnetIDs = &subIDs
+	}
+
+	if sgVal, ok := annotations[AnnotationKeyHighScaleNetworkSecurityGroups]; ok {
+		sgsSplit := strings.Split(strings.TrimSpace(sgVal), ",")
+		sgIDs := []string{}
+		for _, sg := range sgsSplit {
+			sgIDs = append(sgIDs, strings.TrimSpace(sg))
+		}
+		pConf.HsSecurityGroups = &sgIDs
+	}
+
+	if subVal, ok := annotations[AnnotationKeyHighScaleNetworkSubnetIDs]; ok {
+		subsSplit := strings.Split(strings.TrimSpace(subVal), ",")
+		subIDs := []string{}
+		for _, sub := range subsSplit {
+			subIDs = append(subIDs, strings.TrimSpace(sub))
+		}
+		pConf.HsSubnetIDs = &subIDs
 	}
 
 	if envVal, ok := annotations[AnnotationKeyPodTitusSystemEnvVarNames]; ok {

--- a/pod/config.go
+++ b/pod/config.go
@@ -26,6 +26,8 @@ type Config struct {
 	EntrypointShellSplitting *bool
 	FuseEnabled              *bool
 	HostnameStyle            *string
+	HsSecurityGroups         *[]string
+	HsSubnetIDs              *[]string
 	IAMRole                  *string
 	InjectedEnvVarNames      []string
 	IngressBandwidth         *resource.Quantity

--- a/pod/config_test.go
+++ b/pod/config_test.go
@@ -103,6 +103,8 @@ func TestParsePod(t *testing.T) {
 		AnnotationKeyNetworkSecurityGroups:         "sg-1 , sg-2 ",
 		AnnotationKeyNetworkStaticIPAllocationUUID: "static-ip-alloc-id",
 		AnnotationKeyNetworkSubnetIDs:              "subnet-1 , subnet-2 ",
+		AnnotationKeyHighScaleNetworkSecurityGroups: "sg-3 , sg-4 ",
+		AnnotationKeyHighScaleNetworkSubnetIDs:     "subnet-3 , subnet-4 ",
 		AnnotationKeyPodTitusSystemEnvVarNames:     "SYSTEM1 , SYSTEM2 ",
 		AnnotationKeyPodInjectedEnvVarNames:        "MUTATED1 , MUTATED2 ",
 
@@ -171,6 +173,8 @@ func TestParsePod(t *testing.T) {
 	assert.NilError(t, err)
 	sgIDs := []string{"sg-1", "sg-2"}
 	subnetIDs := []string{"subnet-1", "subnet-2"}
+	hsSgIDs := []string{"sg-3", "sg-4"}
+	hsSubnetIDs := []string{"subnet-3", "subnet-4"}
 	expConf := Config{
 		AppArmorProfile:          ptr.StringPtr("localhost/docker_titus"),
 		AccountID:                ptr.StringPtr("123456"),
@@ -191,6 +195,8 @@ func TestParsePod(t *testing.T) {
 		EntrypointShellSplitting: ptr.BoolPtr(true),
 		FuseEnabled:              ptr.BoolPtr(true),
 		HostnameStyle:            ptr.StringPtr("ec2"),
+		HsSecurityGroups:         &hsSgIDs,
+		HsSubnetIDs:              &hsSubnetIDs,
 		IAMRole:                  ptr.StringPtr("arn:aws:iam::0:role/DefaultContainerRole"),
 		IMDSRequireToken:         ptr.StringPtr("require-token"),
 		IngressBandwidth:         stringToResourcePtr("20M"),


### PR DESCRIPTION
Create a static config for high scale network mode annotations for security groups and subnet Ids.