### PR TITLE
Added misc constants from the webhook

### DIFF
--- a/pod/misc.go
+++ b/pod/misc.go
@@ -1,0 +1,12 @@
+package pod
+
+const (
+	SchedPriorityFast   = "sched-latency-fast"
+	SchedPriorityMedium = "sched-latency-medium"
+	SchedPriorityDelay  = "sched-latency-delay"
+
+	SchedNameDefault           = "default-scheduler"
+	SchedNameMixed             = "titus-kube-scheduler-mixed"
+	SchedNameReserved          = "titus-kube-scheduler-reserved"
+	SchedNameRservedBinpacking = "titus-kube-scheduler-reserved-binpacking"
+)


### PR DESCRIPTION
This moves the mixed scheduling constants out of the webhook and into
here in kube-common so they can be shared.

I didn't actually grab all of them, maybe yagni. Here was the complete
list:

```
	mixedSchedRouter            = "titus-mixedsched"
	resourcePoolNodeAffinityKey = "scaler.titus.netflix.com/resource-pool"
	resourcePoolElastic         = "elastic"
	resourcePoolReserved        = "reserved"
	mixedSchedulerProfileName   = "titus-kube-scheduler-mixed"
	mixedSchedCG                = "mixed-elastic"
	annotationOverrideFlagKey   = "scaler.titus.netflix.com/resource-pool-selection"
```