### PR TITLE
add pod annotations for recording runtime version information

### DIFF
--- a/pod/annotations.go
+++ b/pod/annotations.go
@@ -234,6 +234,12 @@ const (
 	AnnotationKeyPodParameterMockPodPrepareTime = "mockPod.netflix.com/prepareTime"
 	AnnotationKeyPodParameterMockPodRunTime     = "mockPod.netflix.com/runTime"
 	AnnotationKeyPodParameterMockPodKillTime    = "mockPod.netflix.com/killTime"
+
+	// version recording; this is output from titus-executor mostly used
+	// for debugging. if we decide to add more versions here, let's make it
+	// one annotation with csv or similar.
+	AnnotationKeyRuntimeVersionTitusExecutor = "runtime.version.titus.netflix.com/titus-executor"
+	AnnotationKeyRuntimeVersionLinuxKernel   = "runtime.version.titus.netflix.com/linux-kernel"
 )
 
 func validateImage(image string) error {


### PR DESCRIPTION
The only two (I think) we care about right now are executor version and kernel version. All the sidecars should be in the podspec.

Perhaps TSA version as well?