### PR TITLE
Added annotations for nodes to figure out why they went away

### DIFF
--- a/node/annotations.go
+++ b/node/annotations.go
@@ -12,4 +12,11 @@ const (
 	AnnotationKeyRegion         = "node.titus.netflix.com/region"
 	AnnotationKeyZone           = "node.titus.netflix.com/zone"
 	AnnotationKeyStack          = "node.titus.netflix.com/stack"
+	// AnnotationKeyNodeTerminationReason is a human readable string indicating *why* a node was terminated.
+	// It is the responsibility of any code that calls node.delete() to populate this annotation so that operators
+	// of the system can understand why a node was deleted.
+	AnnotationKeyNodeTerminationReason = "node.titus.netflix.com/node-termination-reason"
+	// AnnotationKeyNodeTerminationByCaller is a human readable string indicating which Titus component actually
+	// deleted the a node, to aid operators in investigating "why did this node go away".
+	AnnotationKeyNodeTerminationByCaller = "node.titus.netflix.com/node-termination-by-caller"
 )


### PR DESCRIPTION
Analagous to the PodTerminationReasons, I would like to annotate our nodes with human readable reasons for why they went away.

Nodes can go away for any number of reasons (sudo halt), and the more metadata we can add, the easier we can make our lives in debugging or explaining what happened.